### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-selenium==3.4.3
+selenium==3.13.0
 six==1.10.0
-taskcluster==2.1.3
+taskcluster==4.0.0
 -e git+https://github.com/marco-c/firefox-code-coverage@1.0.0#egg=firefox_code_coverage


### PR DESCRIPTION
I noticed a failure in `mozilla/release-servies` relevant to outdated version of taskcluster in `coverage-crawler`. 