### PR TITLE
Return absolute path instead of relative

### DIFF
--- a/coverage_crawler/crawler.py
+++ b/coverage_crawler/crawler.py
@@ -290,4 +290,4 @@ def run(website):
 
         driver.quit()
 
-        return '{}/report'.format(data_folder)
+        return os.path.abspath(os.path.join(os.getcwd(), '{}/report'.format(data_folder)))


### PR DESCRIPTION
In that way, it is easier to pass it to GitHub upload module.